### PR TITLE
Fixes to encoding and line numbers.

### DIFF
--- a/handout.tex
+++ b/handout.tex
@@ -24,18 +24,28 @@ $endif$
 
 % ams
 \usepackage{amssymb,amsmath}
+
+\usepackage{ifxetex,ifluatex}
+\usepackage{fixltx2e} % provides \textsubscript
+\ifnum 0\ifxetex 1\fi\ifluatex 1\fi=0 % if pdftex
+  \usepackage[T1]{fontenc}
+  \usepackage[utf8]{inputenc}
+
  
 % add line numbers (Caleb McDaniel)
 $if(linenos)$
 \usepackage[modulo]{lineno}
 \linenumbers
+\def\linenumberfont{\normalfont\small}
 $endif$
 
 % use symbols instead of numbers for footnotes (Caleb McDaniel)
 % http://tex.stackexchange.com/questions/826/symbols-instead-of-numbers-as-footnote-markers
+$if(symbol)$
 \usepackage{perpage}
 \MakePerPage{footnote}
 \renewcommand*{\thefootnote}{\fnsymbol{footnote}}
+$endif$
 
 % Set up the images/graphics package
 \usepackage{graphicx}


### PR DESCRIPTION
This allows for basic accented characters and sets the font of the line numbers to match the text. I also made the symbols optional, since this doesn't work for documents with more than a handful of notes. Thanks for your work on this: I used it for <https://github.com/adunning/early-lives-charlemagne>.