### PR TITLE
Fix missing \fi

### DIFF
--- a/handout.tex
+++ b/handout.tex
@@ -30,7 +30,7 @@ $endif$
 \ifnum 0\ifxetex 1\fi\ifluatex 1\fi=0 % if pdftex
   \usepackage[T1]{fontenc}
   \usepackage[utf8]{inputenc}
-
+\fi
  
 % add line numbers (Caleb McDaniel)
 $if(linenos)$


### PR DESCRIPTION
This is mostly relevant for xetex and luatex as pdftex will just swallow the rest of the document without the need for an explicit \fi.
